### PR TITLE
Restore compatibility with Python 3.8 and 3.9

### DIFF
--- a/scripts/db/app_state.py
+++ b/scripts/db/app_state.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Union
 
 from sqlalchemy import Column, String
 from sqlalchemy.orm import Session
@@ -35,7 +36,7 @@ class AppStateTable(Base):
 
 
 class AppStateManager(BaseTableManager):
-    def get_value(self, key: str) -> str | None:
+    def get_value(self, key: str) -> Union[str, None]:
         session = Session(self.engine)
         try:
             result = session.get(AppStateTable, key)

--- a/scripts/db/task.py
+++ b/scripts/db/task.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Union
 
 from sqlalchemy import Column, String, Text, Integer, DateTime, LargeBinary, text, func
 from sqlalchemy.orm import Session
@@ -115,7 +115,7 @@ class TaskTable(Base):
 
 
 class TaskManager(BaseTableManager):
-    def get_task(self, id: str) -> TaskTable | None:
+    def get_task(self, id: str) -> Union[TaskTable, None]:
         session = Session(self.engine)
         try:
             task = session.get(TaskTable, id)


### PR DESCRIPTION
The | operator for types, instead of Union, is only supported for Python 3.10 onwards. However, Google Colab and Paperspace, and possibly others, default to Python 3.8 or 3.9.
Restore compatibility by using typing.Union instead.

Fixes #6.