### PR TITLE
Fix an issue querying task results in the case of an unfinished task

### DIFF
--- a/agent_scheduler/api.py
+++ b/agent_scheduler/api.py
@@ -235,7 +235,7 @@ def regsiter_apis(app: App, task_runner: TaskRunner):
             return {"success": False, "message": "Task not found"}
 
         if task.status != TaskStatus.DONE:
-            return {"success": False, "message": f"Task is {task.status.value}"}
+            return {"success": False, "message": f"Task is {task.status}"}
 
         if task.result is None:
             return {"success": False, "message": "Task result is not available"}


### PR DESCRIPTION
Without the patch this is what you get when you query a task that is processing:

    {"error"=>"AttributeError", "detail"=>"", "body"=>"", "errors"=>"'str' object has no attribute 'value'"}

This is because the task.status object in the patched line is a string, so it has no `value` property.