### PR TITLE
fix : APIError, infotexts can be None

### DIFF
--- a/agent_scheduler/api.py
+++ b/agent_scheduler/api.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import io
 import os
 import json
@@ -445,7 +446,7 @@ def regsiter_apis(app: App, task_runner: TaskRunner):
             return {"success": False, "message": "Task result is not available"}
 
         result: dict = json.loads(task.result)
-        infotexts = result["infotexts"]
+        infotexts = result.get("infotexts", defaultdict(lambda: ""))
 
         if zip:
             zip_buffer = io.BytesIO()


### PR DESCRIPTION
```
*** API error: GET: http://127.0.0.1:9051/agent-scheduler/v1/results/1699316c-6a81-45a5-812b-042f70d2bc11 {'error': 'KeyError', 'detail': '', 'body': '', 'errors': "'infotexts'"}               | 17/46 [00:09<00:06,  4.57it/s]
    Traceback (most recent call last):
      File "/data/stable-diffusion-webui/venv/lib/python3.10/site-packages/anyio/streams/memory.py", line 98, in receive
        return self.receive_nowait()
      File "/data/stable-diffusion-webui/venv/lib/python3.10/site-packages/anyio/streams/memory.py", line 93, in receive_nowait
        raise WouldBlock
    anyio.WouldBlock

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/data/stable-diffusion-webui/venv/lib/python3.10/site-packages/starlette/middleware/base.py", line 78, in call_next
        message = await recv_stream.receive()
      File "/data/stable-diffusion-webui/venv/lib/python3.10/site-packages/anyio/streams/memory.py", line 118, in receive
        raise EndOfStream
    anyio.EndOfStream

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/data/stable-diffusion-webui/modules/api/api.py", line 187, in exception_handling
        return await call_next(request)

      File "/data/stable-diffusion-webui/extensions/sd-webui-agent-scheduler/agent_scheduler/api.py", line 448, in get_task_results
        infotexts = result["infotexts"]
    KeyError: 'infotexts'
```
