### PR TITLE
Add option to reset 'action after queue completion' after one execution

### DIFF
--- a/agent_scheduler/task_runner.py
+++ b/agent_scheduler/task_runner.py
@@ -544,6 +544,12 @@ class TaskRunner:
         if action == "Do nothing":
             return
 
+        reset_action = getattr(shared.opts, "queue_completion_action_reset", "No")
+        if reset_action == "Yes":
+            log.info(f"[AgentScheduler] Resetting queue_completion_action to 'Do nothing'")
+            setattr(shared.opts, "queue_completion_action", "Do nothing")
+            shared.opts.save(shared.config_filename)
+
         command = None
         if action == "Shut down":
             log.info("[AgentScheduler] Shutting down...")

--- a/scripts/task_scheduler.py
+++ b/scripts/task_scheduler.py
@@ -759,6 +759,16 @@ def on_ui_settings():
             section=section,
         ),
     )
+    shared.opts.add_option(
+        "queue_completion_action_reset",
+        shared.OptionInfo(
+            "No",
+            "Reset 'action after queue completion' to 'Do nothing' after one execution",
+            gr.Radio,
+            {"choices": ["No", "Yes"],},
+            section=section,
+        ),
+    )
 
 
 def on_app_started(block: gr.Blocks, app):


### PR DESCRIPTION
After completion, I sometimes want to shutdown my PC. In most cases, I forget to disable the corresponding setting the next day so my PC shuts down unvoluntarily.
This PR introduces an option to automatically reset the 'action after queue completion' to its default value "Do nothing" after when the action gets triggert once.

This doesn't change the previous default behaviour.