### PR TITLE
fix: controlnet args structure to match upstream structure

### DIFF
--- a/agent_scheduler/task_helpers.py
+++ b/agent_scheduler/task_helpers.py
@@ -227,7 +227,7 @@ def map_controlnet_args_to_api_task_args(args: Dict):
         args = args.__dict__
 
     for k, v in args.items():
-        if (k == "image" || k == "mask") and v is not None:
+        if (k == "image" or k == "mask") and v is not None:
             args[k] = encode_image_to_base64(v)
         if isinstance(v, Enum):
             args[k] = v.value

--- a/agent_scheduler/task_helpers.py
+++ b/agent_scheduler/task_helpers.py
@@ -227,11 +227,8 @@ def map_controlnet_args_to_api_task_args(args: Dict):
         args = args.__dict__
 
     for k, v in args.items():
-        if k == "image" and v is not None:
-            args[k] = {
-                "image": encode_image_to_base64(v["image"]),
-                "mask": encode_image_to_base64(v["mask"]) if v.get("mask", None) is not None else None,
-            }
+        if (k == "image" || k == "mask") and v is not None:
+            args[k] = encode_image_to_base64(v)
         if isinstance(v, Enum):
             args[k] = v.value
 


### PR DESCRIPTION
before : args {image: {image: "", mask: "" }
now: args {image: "", mask: ""}


Error with before:  TypeError: string indices must be integers, not 'str'
response now: {"task_id":"9dca9d76-142e-4c42-ae28-0fdf5f57dc35"}